### PR TITLE
Gallery block is now allwed in wp-gutenberg-epfl plugin

### DIFF
--- a/EPFL_block_white_list.php
+++ b/EPFL_block_white_list.php
@@ -13,7 +13,7 @@ function epfl_allowed_block_types( $allowed_block_types, $post ) {
     NOTES:
     - A block cannot be in both list at the same time.
     - For EPFL blocks allowed in Posts, please have a look a wp-epfl-gutenberg plugin (plugin.php) file*/
-    $post_only_blocks = array('core/gallery',
+    $post_only_blocks = array(
         'core/heading',
         'core/image',
         'core/file',
@@ -24,7 +24,6 @@ function epfl_allowed_block_types( $allowed_block_types, $post ) {
         'tadv/classic-paragraph');
 
     $rest_of_allowed_blocks = array(
-        'core/gallery',
         'core/classic',
         'core/rss',
         'core/shortcode',


### PR DESCRIPTION
Le bloc `core/gallery` n'est maintenant plus autorisé car remplacé par `epfl/gallery` dans https://github.com/epfl-si/wp-gutenberg-epfl/commits/add-epfl-gallery