### PR TITLE
Hide TinyMCE image alignment buttons

### DIFF
--- a/EPFL_installs_locked.php
+++ b/EPFL_installs_locked.php
@@ -3,7 +3,7 @@
  * Plugin Name: EPFL lock plugin and theme install and configuration
  * Plugin URI:
  * Description: Must-use plugin for the EPFL website.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: wwp-admin@epfl.ch
  * */
 
@@ -140,3 +140,18 @@ function EPFL_remove_theme_reference_widget() {
     }
 }
 add_action( 'admin_init','EPFL_remove_theme_reference_widget', 100 );
+
+
+/**
+ * Hides TinyMCE buttons to set image alignment
+ */
+function hide_tinymce_img_align() {
+
+    $css = '.mce-i-dashicon.dashicons-align-left, .mce-i-dashicon.dashicons-align-center, .mce-i-dashicon.dashicons-align-right { display: none; }';
+
+    wp_register_style( 'tinymce-hide-img-align-style', false );
+    wp_enqueue_style( 'tinymce-hide-img-align-style');
+    wp_add_inline_style( 'tinymce-hide-img-align-style', $css );
+
+}
+add_action( 'admin_enqueue_scripts', 'hide_tinymce_img_align' );


### PR DESCRIPTION
Vu que ça n'a strictement aucun effet sur le rendu, il a été demandé de masquer les boutons permettant d'aligner une image lorsque celle-ci est ajoutée via TinyMCE.

On passe donc de 
![image](https://user-images.githubusercontent.com/11942430/81047117-107e5f00-8eba-11ea-97c5-abe310e71c0c.png)
à
![image](https://user-images.githubusercontent.com/11942430/81047137-1f651180-8eba-11ea-8ee9-6bec4c7eb1c0.png)

Le plus aisé (et la première solution trouvée) a été de simplement utiliser du CSS dans la partie admin pour masquer ces éléments. J'ai choisi d'ajouter ce CSS de manière "inline" car faire un fichier CSS dédié pour ça aurait impliqué de "complexifier" le mu-plugin et de le transformer pour qu'il ait un loader, ce qui aurait aussi impliqué de modifications dans Ansible et la manière dont l'image est construite et je trouvais ça un peu overkill.