### PR TITLE
Hide 'Page Attributes' panel to non-admin

### DIFF
--- a/EPFL_custom_editor_menu_loader.php
+++ b/EPFL_custom_editor_menu_loader.php
@@ -3,7 +3,7 @@
 * Plugin Name: EPFL custom editor role menu
 * Plugin URI:
 * Description: Must-use plugin for the EPFL website.
-* Version: 1.0.7
+* Version: 1.1.0
 * Author: wwp-admin@epfl.ch
  */
 

--- a/epfl-custom-editor-menu/epfl-custom-editor-menu-editor.js
+++ b/epfl-custom-editor-menu/epfl-custom-editor-menu-editor.js
@@ -1,3 +1,3 @@
 
-
+// We're simply hiding "Page Attribute" panel on the editor's right side
 wp.data.dispatch('core/edit-post').removeEditorPanel('page-attributes');

--- a/epfl-custom-editor-menu/epfl-custom-editor-menu-editor.js
+++ b/epfl-custom-editor-menu/epfl-custom-editor-menu-editor.js
@@ -1,0 +1,3 @@
+
+
+wp.data.dispatch('core/edit-post').removeEditorPanel('page-attributes');

--- a/epfl-custom-editor-menu/epfl-custom-editor-menu.php
+++ b/epfl-custom-editor-menu/epfl-custom-editor-menu.php
@@ -20,11 +20,9 @@ function add_gutenberg_custom_editor_menu() {
 	}
 }
 
-
 // Gutenberg is on ?
 if (function_exists( 'register_block_type' ) ) {
 	add_action( 'enqueue_block_editor_assets', 'add_gutenberg_custom_editor_menu' );
-	
 }
 
 ?>

--- a/epfl-custom-editor-menu/epfl-custom-editor-menu.php
+++ b/epfl-custom-editor-menu/epfl-custom-editor-menu.php
@@ -7,11 +7,24 @@ function add_gutenberg_custom_editor_menu() {
 		content_url() . '/mu-plugins/epfl-custom-editor-menu/epfl-custom-editor-menu.js',
 		array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element' )
 	);
+
+	// If we're in the admin section and user is not an administrator,
+	if(is_admin() && !current_user_can('administrator') )
+	{
+		// We add a script to hide "Page Attributes" panel on the editor right side
+		wp_enqueue_script(
+			'wp-gutenberg-epfl-custom-editor-menu-editor',
+			content_url() . '/mu-plugins/epfl-custom-editor-menu/epfl-custom-editor-menu-editor.js',
+			array( 'wp-editor', 'wp-blocks', 'wp-i18n', 'wp-element' )
+		);
+	}
 }
+
 
 // Gutenberg is on ?
 if (function_exists( 'register_block_type' ) ) {
 	add_action( 'enqueue_block_editor_assets', 'add_gutenberg_custom_editor_menu' );
+	
 }
 
 ?>


### PR DESCRIPTION
Le panel "Page Attributes" (qui permet de sélectionner le template de la page) est caché par défaut aux personnes qui ne sont pas administratrices.

J'ai voulu utiliser à 100% du JavaScript pour aussi savoir quel était le rôle de l'utilisateur courant (admin, editor) mais pas trouvé comment faire en JavaScript. Du coup, j'ai ajouté un nouveau fichier JS et celui-ci est inclus via PHP uniquement si l'utilisateur connecté n'est pas admin.

Si y'a moyen de faire tout en JS, je suis ouvert aux suggestions.