### PR TITLE
If port is 8443, allow wp-json API traffic

### DIFF
--- a/epfl-functions.php
+++ b/epfl-functions.php
@@ -562,6 +562,9 @@ function disable_rest_api_for_unlogged_users($access) {
     if (is_user_logged_in()) { return $access; }
     if (strpos($_SERVER['REQUEST_URI'], 'wp-json/epfl') !== false) { return $access; }
     if (strpos($_SERVER['REQUEST_URI'], 'epfl-external-menu') !== false) { return $access; }
+    // This is guaranteed (by Kubernetes) to be traffic coming from the same namespace
+    // only.
+    if ($_SERVER['SERVER_PORT'] == 8443) { return $access; }
 
     return new WP_Error(
         'rest_cannot_access',

--- a/epfl-functions.php
+++ b/epfl-functions.php
@@ -559,16 +559,14 @@ add_action( 'wp_enqueue_scripts', 'remove_old_jquery_for_pdf_viewer', 9999);
  * /wp-json/wp/v2/epfl-external-menu
  */
 function disable_rest_api_for_unlogged_users($access) {
-    if (! is_user_logged_in()) {
-        if (strpos($_SERVER['REQUEST_URI'], 'wp-json/epfl') == false and
-            strpos($_SERVER['REQUEST_URI'], 'epfl-external-menu') == false) {
-            return new WP_Error(
-                'rest_cannot_access',
-                __('Only authenticated users can access the REST API.', 'disable-json-api'),
-                array('status' => rest_authorization_required_code() ));
-        }
-    }
-    return $access;
+    if (is_user_logged_in()) { return $access; }
+    if (strpos($_SERVER['REQUEST_URI'], 'wp-json/epfl') !== false) { return $access; }
+    if (strpos($_SERVER['REQUEST_URI'], 'epfl-external-menu') !== false) { return $access; }
+
+    return new WP_Error(
+        'rest_cannot_access',
+        __('Only authenticated users can access the REST API.', 'disable-json-api'),
+        array('status' => rest_authorization_required_code() ));
 }
 
 add_filter( 'rest_authentication_errors', 'disable_rest_api_for_unlogged_users' );


### PR DESCRIPTION
This port is never in use in production right now. All SSL termination is performed in the A10 hardware, and traffic from there  to Apaches flows through ports 8080 (of service VIPs, and from then, of pods).

- Re-use that port to authenticate internal traffic (i.e. for a prober)
- `disable_rest_api_for_unlogged_users()`: whitelist traffic from that port
