### PR TITLE
Fix media folder asking for the setup page

### DIFF
--- a/epfl-functions.php
+++ b/epfl-functions.php
@@ -527,6 +527,11 @@ add_filter( 'option_enlighter-activation-redirect', function( $value ) {
     return '';
 });
 
+# Deactivate the "setup after insall/update" for WP Media folder
+add_action( 'admin_init', function() {
+  update_option('_wpmf_activation_redirect', 1);
+}, 1);
+
 # Deactivate the "Install wizard" for WP Media folder
 add_filter('wpmf_user_can', function( $default_value, $action ) {
     if ($action === 'first_install_plugin') {

--- a/epfl-functions.php
+++ b/epfl-functions.php
@@ -529,7 +529,9 @@ add_filter( 'option_enlighter-activation-redirect', function( $value ) {
 
 # Deactivate the "setup after insall/update" for WP Media folder
 add_action( 'admin_init', function() {
-  update_option('_wpmf_activation_redirect', 1);
+  if (is_plugin_active('wp-media-folder/wp-media-folder.php')) {
+    update_option('_wpmf_activation_redirect', 1);
+  }
 }, 1);
 
 # Deactivate the "Install wizard" for WP Media folder


### PR DESCRIPTION
Force deactivation of the "activation redirect", as we don't want to setup WPMF
Should counter this line:
class/class-main.php:320
```
        // Setup wizard redirect
        if (is_null(get_option('_wpmf_activation_redirect', null)) && is_null(get_option('wpmf_version', null))) {
```