### PR TITLE
Fix using direct function inside an add_filter

### DIFF
--- a/epfl-functions.php
+++ b/epfl-functions.php
@@ -718,5 +718,5 @@ function replace_wp_headers($headers) {
   $headers['X-Frame-Options'] = 'DENY';
   return $headers;
 }
-add_filter('wp_headers', replace_wp_headers);
+add_filter('wp_headers', 'replace_wp_headers');
 


### PR DESCRIPTION
Got this error :
` Warning: Use of undefined constant replace_wp_headers - assumed 'replace_wp_headers' (this will throw an Error in a future version of PHP) in /wp/5.5.3/wp-content/mu-plugins/epfl-functions.php on line 721`