### PR TITLE
[feature] hide redirection menu for not admin users

### DIFF
--- a/EPFL_custom_editor_menu_loader.php
+++ b/EPFL_custom_editor_menu_loader.php
@@ -10,3 +10,14 @@
 
 
 require (WPMU_PLUGIN_DIR.'/epfl-custom-editor-menu/epfl-custom-editor-menu.php');
+
+
+function remove_redirection_from_tools_menu_for_editor() {
+    $user = wp_get_current_user();
+    if (!in_array('administrator', $user->roles)) {
+	    remove_submenu_page('tools.php', 'redirection.php');
+    }
+}
+
+add_action('admin_menu', 'remove_redirection_from_tools_menu_for_editor', 999);
+


### PR DESCRIPTION
Only admins can manage Redirection plugin in Tools menu. The others cannot see the submenu.