### PR TITLE
[unfeature] Mask WordPress-provided “site health“ feature

### DIFF
--- a/EPFL-remove-site-health.php
+++ b/EPFL-remove-site-health.php
@@ -1,0 +1,14 @@
+<?php
+  /**
+   * Remove the Site Health features (dashboard and menu)
+   */
+
+add_action("wp_dashboard_setup", function() {
+    global $wp_meta_boxes;
+    unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_site_health'] );
+});
+
+
+add_action("admin_menu", function() {
+    remove_submenu_page( 'tools.php', 'site-health.php' );
+});


### PR DESCRIPTION
Before:

<img width="1374" height="994" alt="image" src="https://github.com/user-attachments/assets/ebfe80d6-759a-4e01-9297-c26474b14418" />
