### PR TITLE
[feature] Create / delete Entra credentials from a mu-plugin

### DIFF
--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -86,6 +86,14 @@ class WordPress {
 
     return "https://{$hostname}{$path}/wp-admin/admin-ajax.php?action=openid-connect-authorize";
   }
+
+  public function use_new_entra_app ($api) {
+      $oidc_settings = get_option("openid_connect_generic_settings");
+      $credentials = $api->create_entra_app();
+      # TODO: augment $oidc_settings with $credentials
+
+      set_option("openid_connect_generic_settings", $oidc_settings);
+  }
 }
 
 class AppPortalAPI {
@@ -262,13 +270,8 @@ define(OPENID_PLUGIN, 'openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
   add_action('activated_plugin', function ($plugin, $network_wide) {
-      $oidc_settings = get_option("openid_connect_generic_settings");
-
-      $credentials = $api->create_entra_app(WordPress::this_site());
-      # TODO: augment $oidc_settings with $credentials
-
-      set_option("openid_connect_generic_settings", $oidc_settings);
     if ($plugin === OPENID_PLUGIN) {
+      WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);
 

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -71,10 +71,20 @@ class WordPress {
       $hostnames = array_merge($hostnames, $this->get_additional_test_hostnames());
     }
 
-    $path = $p["path"];
     return array_map(function ($hostname) use ($path) {
-      return "https://{$hostname}{$path}/wp-admin/admin-ajax.php?action=openid-connect-authorize";
+      return $this->get_redirect_uri($hostname);
     }, $hostnames);
+  }
+
+  public function get_redirect_uri ($hostname = NULL) {
+    $p = parse_url($this->url);
+
+    if ($hostname === NULL) {
+      $hostname = $p["host"];
+    }
+    $path = $p["path"];
+
+    return "https://{$hostname}{$path}/wp-admin/admin-ajax.php?action=openid-connect-authorize";
   }
 }
 

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -258,20 +258,22 @@ class AppPortalAPI {
 
 $api = AppPortalAPI();
 
+define(OPENID_PLUGIN, 'openid-connect-generic/openid-connect-generic.php');
+
 if ($api->is_available()) {
   add_action('activated_plugin', function ($plugin, $network_wide) {
-    if ($plugin === 'openid-connect-generic/openid-connect-generic.php') {
       $oidc_settings = get_option("openid_connect_generic_settings");
 
       $credentials = $api->create_entra_app(WordPress::this_site());
       # TODO: augment $oidc_settings with $credentials
 
       set_option("openid_connect_generic_settings", $oidc_settings);
+    if ($plugin === OPENID_PLUGIN) {
     }
   }, 10, 2);
 
   add_action('deactivated_plugin', function ($plugin, $network_wide) {
-    if ($plugin === 'openid-connect-generic/openid-connect-generic.php') {
+    if ($plugin === OPENID_PLUGIN) {
       $api->delete_entra_app(WordPress::this_site());
     }
   }, 10, 2);

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -39,7 +39,18 @@ class WordPress {
   public $tagline;
   public $appId;
 
-  private const FRUIT = ["apple", "grapes", "kiwi", "lemon", "orange"];
+  private function get_additional_test_hostnames () {
+    # TODO: maybe we could find a way to plumb this down better than a constant list.
+    return [
+      "wp-test-apple.epfl.ch",
+      "wp-test-grapes.epfl.ch",
+      "wp-test-kiwi.epfl.ch",
+      "wp-test-lemon.epfl.ch",
+      "wp-test-orange.epfl.ch",
+      "wp-test-alpha.epfl.ch",
+      "wp-test-rc.epfl.ch"
+    ];
+  }
 
   public function __construct ($url, $tagline, $appId) {
     $this->url     = $url;
@@ -57,9 +68,7 @@ class WordPress {
     $p = parse_url($this->url);
     $hostnames = [$p["host"]];
     if ($p["host"] === "wpn-test.epfl.ch") {
-      foreach ($this->FRUIT as $fruit) {
-        $hostnames[] = "wp-test-{$fruit}.epfl.ch";
-      }
+      $hostnames = array_merge($hostnames, $this->get_additional_test_hostnames());
     }
 
     $path = $p["path"];

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -88,6 +88,7 @@ class WordPress {
   }
 
   public function use_new_entra_app ($api) {
+      echo "\nCreating app ...\n";
       $oidc_settings = get_option("openid_connect_generic_settings");
       $appId = $api->create_entra_app()["appId"];
 
@@ -119,7 +120,8 @@ class WordPress {
       $oidc_settings["enable_logging"] = "";
       $oidc_settings["log_limit"] = "";
 
-      set_option("openid_connect_generic_settings", $oidc_settings);
+      echo "\nSetting options ...\n";
+	  set_option("openid_connect_generic_settings", $oidc_settings);
   }
 }
 
@@ -130,8 +132,10 @@ class AppPortalAPI {
     $tenantId     = getenv('ENTRA_APP_TENANT_ID');
 
     if ($clientId && $clientSecret && $tenantId) {
+      echo "\nSecrets are defined\n";
       return [$clientId, $clientSecret, $tenantId];
     } else {
+      echo "\nSecrets are not defined\n";
       return NULL;
     }
   }
@@ -259,6 +263,7 @@ class AppPortalAPI {
   }
 
   public function create_entra_app ($wordpress) {
+    echo "\nCreating app : calling API ...\n";
     $response = $this->call_app_portal_api("POST", "/app-portal-api/v1/portal/oidc-apps", [
       authorizedUsers => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
       config_desc => "WordPress site {$wordpress->url}",
@@ -268,10 +273,13 @@ class AppPortalAPI {
       spa => [ redirectUris => $wordpress->get_oidc_redirect_urls() ],
       unitID => "13030"
     ]);
+    echo "\nCreating app : called API ...\n";
     if (! $response["ok"]) {
+      echo "\nCreating app : called API failed\n";
       throw new RuntimeException("create_entra_app failed: " . json_encode($response));
     }
 
+    echo "\nCreating app : called API success\n";
     return $response["App"];
   }
 
@@ -307,8 +315,10 @@ $api = new AppPortalAPI();
 define('OPENID_PLUGIN', 'openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
+  echo "\nApp portal is available\n";
   add_action('activated_plugin', function ($plugin, $network_wide) {
     if ($plugin === OPENID_PLUGIN) {
+      echo "\nOPENID_PLUGIN has been activated\n";
       WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -132,10 +132,10 @@ class AppPortalAPI {
     $tenantId     = getenv('ENTRA_APP_TENANT_ID');
 
     if ($clientId && $clientSecret && $tenantId) {
-      echo "\nSecrets are defined\n";
+      echo "\nENTRA-MUPLUGIN - Secrets are defined\n";
       return [$clientId, $clientSecret, $tenantId];
     } else {
-      echo "\nSecrets are not defined\n";
+      echo "\nENTRA-MUPLUGIN - Secrets are not defined\n";
       return NULL;
     }
   }
@@ -273,13 +273,7 @@ class AppPortalAPI {
       "spa" => [ "redirectUris" => $wordpress->get_oidc_redirect_urls() ],
       "unitID" => "13030"
     ]);
-    echo "\nCreating app : called API ...\n";
-    if (! $response["ok"]) {
-      echo "\nCreating app : called API failed\n";
-      throw new \RuntimeException("create_entra_app failed: " . json_encode($response));
-    }
-
-    echo "\nCreating app : called API success\n";
+    echo "\nENTRA-MUPLUGIN - App created\n";
     return $response["App"];
   }
 
@@ -315,10 +309,10 @@ $api = new AppPortalAPI();
 define('OPENID_PLUGIN', 'daggerhart-openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
-  echo "\nApp portal is available\n";
+  echo "\nENTRA-MUPLUGIN - App portal is available\n";
   add_action('activated_plugin', function ($plugin, $network_wide) use ($api) {
     if ($plugin === OPENID_PLUGIN) {
-      echo "\nOPENID_PLUGIN has been activated\n";
+      echo "\nENTRA-MUPLUGIN - OPENID_PLUGIN has been activated\n";
       WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Integration with EPFL Entra
+ *
+ * This must-use plugin ensures that the `openid-connect-generic`
+ * plug-in is configured to authenticate with Microsoft Entra.
+ *
+ * In the EPFL setup, acquiring / destroying the relevant credentials
+ * is done via a REST API hosted at app-portal.epfl.ch. For security
+ * reasons, the credentials to this REST API are *not* made available
+ * to the main (interactive) Web pods; rather, the 
+ *
+ * @link              https://app-portal.epfl.ch/
+ * @package           EFPL-MU-plugins
+ *
+ * @wordpress-plugin
+ * Plugin Name:       Entra App Portal
+ * Plugin URI:        https://github.com/epfl-si/wp-mu-plugins
+ * Description:       Manage Entra credentials via app-portal.epfl.ch
+ * Version:           0.1.0
+ * Author:            EPFL ISAS-FSD
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       EFPL-MU-plugins
+ */
+
+namespace EPFL\AppPortal;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+
+/**
+ * Abstraction for the Entra-relevant data of this (or any) WordPress instance.
+ */
+class WordPress {
+  public $url;
+  public $tagline;
+  public $appId;
+
+  private const FRUIT = ["apple", "grapes", "kiwi", "lemon", "orange"];
+
+  public function __construct ($url, $tagline, $appId) {
+    $this->url     = $url;
+    $this->tagline = $tagline;
+    $this->appId   = $appId;
+  }
+
+  public static function this_site () {
+    return new static(
+      \site_url(), \get_bloginfo("description"),
+      @get_option("openid_connect_generic_settings")["client_id"]);
+  }
+
+  public function get_oidc_redirect_urls () {
+    $p = parse_url($this->url);
+    $hostnames = [$p["host"]];
+    if ($p["host"] === "wpn-test.epfl.ch") {
+      foreach ($this->FRUIT as $fruit) {
+        $hostnames[] = "wp-test-{$fruit}.epfl.ch";
+      }
+    }
+
+    $path = $p["path"];
+    return array_map(function ($hostname) use ($path) {
+      return "https://{$hostname}{$path}/wp-admin/admin-ajax.php?action=openid-connect-authorize";
+    }, $hostnames);
+  }
+}
+
+class AppPortalAPI {
+  private function get_api_credentials () {
+    $clientId     = getenv('ENTRA_APP_CLIENT_ID');
+    $clientSecret = getenv('ENTRA_APP_CLIENT_SECRET');
+    $tenantId     = getenv('ENTRA_APP_TENANT_ID');
+
+    if ($clientId && $clientSecret && $tenantId) {
+      return [$clientId, $clientSecret, $tenantId];
+    } else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Tell whether this entire mu-plugin should be active or inactive.
+   *
+   * The intent is for the caller to ensure that this mu-plugin only
+   * be active in “offline” environments, i.e. the WordPress operator
+   * or wp-cron pods; *not* the interactive (Web server) pods.
+   *
+   * @return TRUE iff credentials to the app-portal API are available in the process environment.
+   */
+  public function is_available () {
+    return $this->get_api_credentials() !== NULL;
+  }
+
+  private $cached_token;
+
+  private function get_token () {
+    if ($this->cached_token) return $this->cached_token;
+
+    $credentials = $this->get_api_credentials();
+    if ($credentials === NULL) {
+      throw new RuntimeException("No app-portal credentials available.");
+    }
+
+    [$clientId, $clientSecret, $tenantId] = $credentials;
+    
+    $url = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/token";
+
+    $postFields = http_build_query([
+      'client_id'     => $clientId,
+      'client_secret' => $clientSecret,
+      'scope'         => "api://{$clientId}/.default",
+      'grant_type'    => 'client_credentials',
+    ]);
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+      CURLOPT_POST            => true,
+      CURLOPT_POSTFIELDS      => $postFields,
+      CURLOPT_RETURNTRANSFER  => true,
+      CURLOPT_HTTPHEADER      => [
+        'Content-Type: application/x-www-form-urlencoded',
+      ],
+    ]);
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+      $error = curl_error($ch);
+      curl_close($ch);
+      throw new RuntimeException("cURL error: {$error}");
+    }
+
+    $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpStatus < 200 || $httpStatus >= 300) {
+      throw new RuntimeException("Failed to generate token: {$httpStatus} {$response}");
+    }
+
+    $data = json_decode($response, true);
+    if (isset($data['access_token'])) {
+      $this->token = $data['access_token'];
+      return $this->token;
+    } else {
+      throw new RuntimeException("No access_token in response: {$response}");
+    }
+  }
+
+  private function make_app_portal_url ($url_suffix) {
+    $app_portal_url_base = getenv("APP_PORTAL_URL") ?: "https://app-portal.epfl.ch";
+    $slashsep = substr($url_suffix, 0, 1) == "/" ? "" : "/";
+    return "{$app_portal_url_base}{$slashsep}{$url_suffix}";
+  }
+
+  private function call_app_portal_api ($method, $url_suffix, $body_params = NULL) {
+    $token = $this->get_token();
+
+    $url = make_app_portal_url($url_suffix);
+    $ch = curl_init($url);
+
+    $curlopts = [
+      CURLOPT_RETURNTRANSFER  => true,
+      CURLOPT_HTTPHEADER      => [
+        "Content-Type: application/json",
+        "Authorization: Bearer {$token}"
+      ]
+    ];
+
+    if ($method === "GET") {
+      # Nothing
+    } elseif ($method === "POST") {
+      $curlopts[CURLOPT_POST] = true;
+    } else {
+      $curlopts[CURLOPT_CUSTOMREQUEST] = $method;
+    }
+
+    if ($body_params !== NULL) {
+      $curlopts[CURLOPT_POSTFIELDS] = json_encode($body_params);
+    }
+
+    curl_setopt_array($ch, $curlopts);
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+      $error = curl_error($ch);
+      curl_close($ch);
+      throw new RuntimeException("cURL error at {$url}: {$error}");
+    }
+
+    $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpStatus < 200 || $httpStatus >= 300) {
+      throw new RuntimeException("{$method} call to {$url} failed: {$httpStatus} {$response}");
+    }
+
+    return json_decode($response, true);
+  }
+
+  private function get_environment_id () {
+    return (getenv("ENV") === "prod") ? 3 : 2;
+  }
+
+  public function create_entra_app ($wordpress) {
+    $response = $this->call_app_portal_api("POST", "/app-portal-api/v1/portal/oidc-apps", [
+      authorizedUsers => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
+      config_desc => "WordPress site {$wordpress->url}",
+      description => "Application for site {$wordpress->tagline}",
+      environmentID => $this->get_environment_id(),
+      notes => "Entra application for WordPress site ({$wordpress->url})",
+      spa => [ redirectUris => $wordpress->get_oidc_redirect_urls() ],
+      unitID => "13030"
+    ]);
+    if (! $response["ok"]) {
+      throw new RuntimeException("create_entra_app failed: " . json_encode($response));
+    }
+
+    return $response;
+  }
+
+  public function delete_entra_app ($wordpress) {
+    $response = $this->call_app_portal_api(
+      "DELETE", "/app-portal-api/v1/portal/oidc-apps/{$wordpress->appId}");
+
+    if (! $response["ok"]) {
+      throw new RuntimeException("delete_entra_app failed: " . json_encode($response));
+    }
+
+    return $response;
+  }
+}
+
+$api = AppPortalAPI();
+
+if ($api->is_available()) {
+  add_action('activated_plugin', function ($plugin, $network_wide) {
+    if ($plugin === 'openid-connect-generic/openid-connect-generic.php') {
+      $oidc_settings = get_option("openid_connect_generic_settings");
+
+      $credentials = $api->create_entra_app(WordPress::this_site());
+      # TODO: augment $oidc_settings with $credentials
+
+      set_option("openid_connect_generic_settings", $oidc_settings);
+    }
+  }, 10, 2);
+
+  add_action('deactivated_plugin', function ($plugin, $network_wide) {
+    if ($plugin === 'openid-connect-generic/openid-connect-generic.php') {
+      $api->delete_entra_app(WordPress::this_site());
+    }
+  }, 10, 2);
+}

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -8,7 +8,7 @@
  * In the EPFL setup, acquiring / destroying the relevant credentials
  * is done via a REST API hosted at app-portal.epfl.ch. For security
  * reasons, the credentials to this REST API are *not* made available
- * to the main (interactive) Web pods; rather, the 
+ * to the main (interactive) Web pods; rather, the
  *
  * @link              https://app-portal.epfl.ch/
  * @package           EFPL-MU-plugins
@@ -160,7 +160,7 @@ class AppPortalAPI {
     }
 
     [$clientId, $clientSecret, $tenantId] = $credentials;
-    
+
     $url = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/token";
 
     $postFields = http_build_query([
@@ -304,7 +304,7 @@ class AppPortalAPI {
 
 $api = new AppPortalAPI();
 
-define(OPENID_PLUGIN, 'openid-connect-generic/openid-connect-generic.php');
+define('OPENID_PLUGIN', 'openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
   add_action('activated_plugin', function ($plugin, $network_wide) {

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -252,6 +252,17 @@ class AppPortalAPI {
     return "/app-portal-api/v1/portal/oidc-apps/{$wordpress->appId}";
   }
 
+  public function read_entra_app ($wordpress) {
+    $response = $this->call_app_portal_api(
+      "GET", $this->get_relative_url_of_app($wordpress));
+
+    if (! $response["App"]) {
+      throw new RuntimeException("read_entra_app failed: " . json_encode($response));
+    }
+
+    return $response["App"];
+  }
+
   public function delete_entra_app ($wordpress) {
     $response = $this->call_app_portal_api(
       "DELETE", $this->get_relative_url_of_app($wordpress));
@@ -280,4 +291,17 @@ if ($api->is_available()) {
       $api->delete_entra_app(WordPress::this_site());
     }
   }, 10, 2);
+
+  add_action('wp_operator_post_restore', function ($unused) {
+    if (! is_plugin_active(OPENID_PLUGIN)) return;
+
+    foreach ($api->read_entra_app($this_site)["redirectURIs"] as $redirect_uri) {
+      if ($redirect_uri === $this_site->get_redirect_uri()) {
+        return;  # Restore is at same URL as before; dont't touch anything
+      }
+    }
+
+    # Restore is at new URL; need new App Portal credentials
+    $this_site->use_new_entra_app($api);
+  });
 }

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -265,13 +265,13 @@ class AppPortalAPI {
   public function create_entra_app ($wordpress) {
     echo "\nCreating app : calling API ...\n";
     $response = $this->call_app_portal_api("POST", "/app-portal-api/v1/portal/oidc-apps", [
-      authorizedUsers => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
-      config_desc => "WordPress site {$wordpress->url}",
-      description => "Application for site {$wordpress->tagline}",
-      environmentID => $this->get_environment_id(),
-      notes => "Entra application for WordPress site ({$wordpress->url})",
-      spa => [ redirectUris => $wordpress->get_oidc_redirect_urls() ],
-      unitID => "13030"
+      "authorizedUsers" => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
+      "config_desc" => "WordPress site {$wordpress->url}",
+      "description" => "Application for site {$wordpress->tagline}",
+      "environmentID" => $this->get_environment_id(),
+      "notes" => "Entra application for WordPress site ({$wordpress->url})",
+      "spa" => [ "redirectUris" => $wordpress->get_oidc_redirect_urls() ],
+      "unitID" => "13030"
     ]);
     echo "\nCreating app : called API ...\n";
     if (! $response["ok"]) {
@@ -319,7 +319,7 @@ if ($api->is_available()) {
   add_action('activated_plugin', function ($plugin, $network_wide) {
     if ($plugin === OPENID_PLUGIN) {
       echo "\nOPENID_PLUGIN has been activated\n";
-      WordPress::this_site()->use_new_entra_app($api);
+      WordPress::this_site()->use_new_entra_app(new AppPortalAPI());
     }
   }, 10, 2);
 

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -89,8 +89,35 @@ class WordPress {
 
   public function use_new_entra_app ($api) {
       $oidc_settings = get_option("openid_connect_generic_settings");
-      $credentials = $api->create_entra_app();
-      # TODO: augment $oidc_settings with $credentials
+      $appId = $api->create_entra_app()["appId"];
+
+      $oidc_settings["login_type"] = "auto";
+      $oidc_settings["client_id"] = $appId;
+      $oidc_settings["client_secret"] = "";  # So-called single-page Web app
+      $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$app->tenantId}/oauth2/v2.0/authorize";
+      $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$app->tenantId}/oauth2/v2.0/token";
+      $oidc_settings["scope"] = "openid profile email {$appId}/.default";
+      $oidc_settings["endpoint_userinfo"] = "https://api.epfl.ch/v2/oidc/userinfo?groups&rights=WordPress.Editor";
+      $oidc_settings["endpoint_end_session"] = "";
+      $oidc_settings["acr_values"] = "";
+
+      $oidc_settings["no_sslverify"] = "";
+      $oidc_settings["http_request_timeout"] = "15";
+      $oidc_settings["identity_key"] = "uniqueid";
+      $oidc_settings["nickname_key"] = "gaspar";
+      $oidc_settings["email_format"] = "{email}";
+      $oidc_settings["displayname_format"] = "";
+      $oidc_settings["identify_with_username"] = "";
+      $oidc_settings["state_time_limit"] = "";
+      $oidc_settings["enforce_privacy"] = "0";
+      $oidc_settings["alternate_redirect_uri"] = "";
+      $oidc_settings["token_refresh_enable"] = "";
+      $oidc_settings["link_existing_users"] = "1";
+      $oidc_settings["create_if_does_not_exist"] = "";
+      $oidc_settings["redirect_user_back"] = "";
+      $oidc_settings["redirect_on_logout"] = "";
+      $oidc_settings["enable_logging"] = "";
+      $oidc_settings["log_limit"] = "";
 
       set_option("openid_connect_generic_settings", $oidc_settings);
   }
@@ -245,7 +272,7 @@ class AppPortalAPI {
       throw new RuntimeException("create_entra_app failed: " . json_encode($response));
     }
 
-    return $response;
+    return $response["App"];
   }
 
   private function get_relative_url_of_app ($wordpress) {

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -240,9 +240,13 @@ class AppPortalAPI {
     return $response;
   }
 
+  private function get_relative_url_of_app ($wordpress) {
+    return "/app-portal-api/v1/portal/oidc-apps/{$wordpress->appId}";
+  }
+
   public function delete_entra_app ($wordpress) {
     $response = $this->call_app_portal_api(
-      "DELETE", "/app-portal-api/v1/portal/oidc-apps/{$wordpress->appId}");
+      "DELETE", $this->get_relative_url_of_app($wordpress));
 
     if (! $response["ok"]) {
       throw new RuntimeException("delete_entra_app failed: " . json_encode($response));

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -121,7 +121,7 @@ class WordPress {
       $oidc_settings["log_limit"] = "";
 
       echo "\nSetting options ...\n";
-	  set_option("openid_connect_generic_settings", $oidc_settings);
+	  update_option("openid_connect_generic_settings", $oidc_settings);
   }
 }
 

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -263,11 +263,17 @@ class AppPortalAPI {
   }
 
   public function create_entra_app ($wordpress) {
-    echo "\nCreating app : calling API ...\n";
+    echo "\nENTRA-MUPLUGIN - Creating app : calling API ...\n";
+    $name = str_replace(".epfl.ch", "",str_replace("/", "-", str_replace("https://","",$wordpress->url)));
+    if (substr($name, -1) === "-") {
+        // Remove the last character
+        $name = substr($name, 0, -1);
+    }
     $response = $this->call_app_portal_api("POST", "/app-portal-api/v1/portal/oidc-apps", [
       "authorizedUsers" => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
       "config_desc" => "WordPress site {$wordpress->url}",
-      "description" => "Application for site {$wordpress->tagline}",
+      "description" => "Application for site" . str_replace("/","-",$wordpress->url),
+      "displayName" => "EPFL - WP ({$name})",
       "environmentID" => $this->get_environment_id(),
       "notes" => "Entra application for WordPress site ({$wordpress->url})",
       "spa" => [ "redirectUris" => $wordpress->get_oidc_redirect_urls() ],

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -302,7 +302,7 @@ class AppPortalAPI {
   }
 }
 
-$api = AppPortalAPI();
+$api = new AppPortalAPI();
 
 define(OPENID_PLUGIN, 'openid-connect-generic/openid-connect-generic.php');
 

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -59,9 +59,11 @@ class WordPress {
   }
 
   public static function this_site () {
+    $option = @get_option("openid_connect_generic_settings");
+    $clientId = $option ? $option["client_id"]: null;
     return new static(
       \site_url(), \get_bloginfo("description"),
-      @get_option("openid_connect_generic_settings")["client_id"]);
+      $clientId);
   }
 
   public function get_oidc_redirect_urls () {
@@ -91,12 +93,13 @@ class WordPress {
       error_log("ENTRA-MUPLUGIN - Creating app ...");
       $oidc_settings = get_option("openid_connect_generic_settings");
       $appId = $api->create_entra_app($this)["appId"];
+      $tenantId = getenv("ENTRA_APP_TENANT_ID");
 
       $oidc_settings["login_type"] = "auto";
       $oidc_settings["client_id"] = $appId;
       $oidc_settings["client_secret"] = "";  # So-called single-page Web app
-      $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$appId}/oauth2/v2.0/authorize";
-      $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$appId}/oauth2/v2.0/token";
+      $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/authorize";
+      $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/token";
       $oidc_settings["scope"] = "openid profile email {$appId}/.default";
       $oidc_settings["endpoint_userinfo"] = "https://api.epfl.ch/v2/oidc/userinfo?groups&rights=WordPress.Editor";
       $oidc_settings["endpoint_end_session"] = "";
@@ -133,10 +136,10 @@ class AppPortalAPI {
     $tenantId     = getenv('ENTRA_APP_TENANT_ID');
 
     if ($clientId && $clientSecret && $tenantId) {
-      
+
       return [$clientId, $clientSecret, $tenantId];
     } else {
-      
+
       return NULL;
     }
   }
@@ -316,20 +319,18 @@ $api = new AppPortalAPI();
 define('OPENID_PLUGIN', 'daggerhart-openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
-  
+
   add_action('activated_plugin', function ($plugin, $network_wide) use ($api) {
     if ($plugin === OPENID_PLUGIN) {
-      
       WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);
 
-//   add_action('deactivated_plugin', function ($plugin, $network_wide) use ($api) {
-//     if ($plugin === OPENID_PLUGIN) {
-      
-//       $api->delete_entra_app(WordPress::this_site());
-//     }
-//   }, 10, 2);
+  add_action('deactivated_plugin', function ($plugin, $network_wide) use ($api) {
+    if ($plugin === OPENID_PLUGIN) {
+      $api->delete_entra_app(WordPress::this_site());
+    }
+  }, 10, 2);
 
   add_action('wp_operator_post_restore', function ($unused) use ($api) {
     if (! is_plugin_active(OPENID_PLUGIN)) return;

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -27,7 +27,7 @@
 namespace EPFL\AppPortal;
 
 if ( ! defined( 'WPINC' ) ) {
-	die;
+    die;
 }
 
 
@@ -71,7 +71,7 @@ class WordPress {
       $hostnames = array_merge($hostnames, $this->get_additional_test_hostnames());
     }
 
-    return array_map(function ($hostname) use ($path) {
+    return array_map(function ($hostname) {
       return $this->get_redirect_uri($hostname);
     }, $hostnames);
   }
@@ -90,13 +90,13 @@ class WordPress {
   public function use_new_entra_app ($api) {
       echo "\nCreating app ...\n";
       $oidc_settings = get_option("openid_connect_generic_settings");
-      $appId = $api->create_entra_app()["appId"];
+      $appId = $api->create_entra_app($this)["appId"];
 
       $oidc_settings["login_type"] = "auto";
       $oidc_settings["client_id"] = $appId;
       $oidc_settings["client_secret"] = "";  # So-called single-page Web app
-      $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$app->tenantId}/oauth2/v2.0/authorize";
-      $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$app->tenantId}/oauth2/v2.0/token";
+      $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$appId}/oauth2/v2.0/authorize";
+      $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$appId}/oauth2/v2.0/token";
       $oidc_settings["scope"] = "openid profile email {$appId}/.default";
       $oidc_settings["endpoint_userinfo"] = "https://api.epfl.ch/v2/oidc/userinfo?groups&rights=WordPress.Editor";
       $oidc_settings["endpoint_end_session"] = "";
@@ -121,7 +121,7 @@ class WordPress {
       $oidc_settings["log_limit"] = "";
 
       echo "\nSetting options ...\n";
-	  update_option("openid_connect_generic_settings", $oidc_settings);
+      update_option("openid_connect_generic_settings", $oidc_settings);
   }
 }
 
@@ -160,7 +160,7 @@ class AppPortalAPI {
 
     $credentials = $this->get_api_credentials();
     if ($credentials === NULL) {
-      throw new RuntimeException("No app-portal credentials available.");
+      throw new \RuntimeException("No app-portal credentials available.");
     }
 
     [$clientId, $clientSecret, $tenantId] = $credentials;
@@ -188,22 +188,22 @@ class AppPortalAPI {
     if ($response === false) {
       $error = curl_error($ch);
       curl_close($ch);
-      throw new RuntimeException("cURL error: {$error}");
+      throw new \RuntimeException("cURL error: {$error}");
     }
 
     $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
     if ($httpStatus < 200 || $httpStatus >= 300) {
-      throw new RuntimeException("Failed to generate token: {$httpStatus} {$response}");
+      throw new \RuntimeException("Failed to generate token: {$httpStatus} {$response}");
     }
 
     $data = json_decode($response, true);
     if (isset($data['access_token'])) {
-      $this->token = $data['access_token'];
-      return $this->token;
+      $this->cached_token = $data['access_token'];
+      return $this->cached_token;
     } else {
-      throw new RuntimeException("No access_token in response: {$response}");
+      throw new \RuntimeException("No access_token in response: {$response}");
     }
   }
 
@@ -216,7 +216,7 @@ class AppPortalAPI {
   private function call_app_portal_api ($method, $url_suffix, $body_params = NULL) {
     $token = $this->get_token();
 
-    $url = make_app_portal_url($url_suffix);
+    $url = $this->make_app_portal_url($url_suffix);
     $ch = curl_init($url);
 
     $curlopts = [
@@ -245,14 +245,14 @@ class AppPortalAPI {
     if ($response === false) {
       $error = curl_error($ch);
       curl_close($ch);
-      throw new RuntimeException("cURL error at {$url}: {$error}");
+      throw new \RuntimeException("cURL error at {$url}: {$error}");
     }
 
     $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
     if ($httpStatus < 200 || $httpStatus >= 300) {
-      throw new RuntimeException("{$method} call to {$url} failed: {$httpStatus} {$response}");
+      throw new \RuntimeException("{$method} call to {$url} failed: {$httpStatus} {$response}");
     }
 
     return json_decode($response, true);
@@ -276,7 +276,7 @@ class AppPortalAPI {
     echo "\nCreating app : called API ...\n";
     if (! $response["ok"]) {
       echo "\nCreating app : called API failed\n";
-      throw new RuntimeException("create_entra_app failed: " . json_encode($response));
+      throw new \RuntimeException("create_entra_app failed: " . json_encode($response));
     }
 
     echo "\nCreating app : called API success\n";
@@ -292,7 +292,7 @@ class AppPortalAPI {
       "GET", $this->get_relative_url_of_app($wordpress));
 
     if (! $response["App"]) {
-      throw new RuntimeException("read_entra_app failed: " . json_encode($response));
+      throw new \RuntimeException("read_entra_app failed: " . json_encode($response));
     }
 
     return $response["App"];
@@ -303,7 +303,7 @@ class AppPortalAPI {
       "DELETE", $this->get_relative_url_of_app($wordpress));
 
     if (! $response["ok"]) {
-      throw new RuntimeException("delete_entra_app failed: " . json_encode($response));
+      throw new \RuntimeException("delete_entra_app failed: " . json_encode($response));
     }
 
     return $response;
@@ -316,22 +316,22 @@ define('OPENID_PLUGIN', 'openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
   echo "\nApp portal is available\n";
-  add_action('activated_plugin', function ($plugin, $network_wide) {
+  add_action('activated_plugin', function ($plugin, $network_wide) use ($api) {
     if ($plugin === OPENID_PLUGIN) {
       echo "\nOPENID_PLUGIN has been activated\n";
-      WordPress::this_site()->use_new_entra_app(new AppPortalAPI());
+      WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);
 
-  add_action('deactivated_plugin', function ($plugin, $network_wide) {
+  add_action('deactivated_plugin', function ($plugin, $network_wide) use ($api) {
     if ($plugin === OPENID_PLUGIN) {
       $api->delete_entra_app(WordPress::this_site());
     }
   }, 10, 2);
 
-  add_action('wp_operator_post_restore', function ($unused) {
+  add_action('wp_operator_post_restore', function ($unused) use ($api) {
     if (! is_plugin_active(OPENID_PLUGIN)) return;
-
+    $this_site = WordPress::this_site();
     foreach ($api->read_entra_app($this_site)["redirectURIs"] as $redirect_uri) {
       if ($redirect_uri === $this_site->get_redirect_uri()) {
         return;  # Restore is at same URL as before; dont't touch anything

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -88,7 +88,7 @@ class WordPress {
   }
 
   public function use_new_entra_app ($api) {
-      echo "\nCreating app ...\n";
+      error_log("ENTRA-MUPLUGIN - Creating app ...");
       $oidc_settings = get_option("openid_connect_generic_settings");
       $appId = $api->create_entra_app($this)["appId"];
 
@@ -120,8 +120,9 @@ class WordPress {
       $oidc_settings["enable_logging"] = "";
       $oidc_settings["log_limit"] = "";
 
-      echo "\nSetting options ...\n";
+      error_log("ENTRA-MUPLUGIN - Setting options ...");
       update_option("openid_connect_generic_settings", $oidc_settings);
+      error_log("ENTRA-MUPLUGIN - Done");
   }
 }
 
@@ -132,10 +133,10 @@ class AppPortalAPI {
     $tenantId     = getenv('ENTRA_APP_TENANT_ID');
 
     if ($clientId && $clientSecret && $tenantId) {
-      echo "\nENTRA-MUPLUGIN - Secrets are defined\n";
+      
       return [$clientId, $clientSecret, $tenantId];
     } else {
-      echo "\nENTRA-MUPLUGIN - Secrets are not defined\n";
+      
       return NULL;
     }
   }
@@ -263,7 +264,7 @@ class AppPortalAPI {
   }
 
   public function create_entra_app ($wordpress) {
-    echo "\nENTRA-MUPLUGIN - Creating app : calling API ...\n";
+    error_log("ENTRA-MUPLUGIN - Creating app : calling API ...");
     $name = str_replace(".epfl.ch", "",str_replace("/", "-", str_replace("https://","",$wordpress->url)));
     if (substr($name, -1) === "-") {
         // Remove the last character
@@ -279,7 +280,7 @@ class AppPortalAPI {
       "spa" => [ "redirectUris" => $wordpress->get_oidc_redirect_urls() ],
       "unitID" => "13030"
     ]);
-    echo "\nENTRA-MUPLUGIN - App created\n";
+    error_log("ENTRA-MUPLUGIN - App created");
     return $response["App"];
   }
 
@@ -315,19 +316,20 @@ $api = new AppPortalAPI();
 define('OPENID_PLUGIN', 'daggerhart-openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
-  echo "\nENTRA-MUPLUGIN - App portal is available\n";
+  
   add_action('activated_plugin', function ($plugin, $network_wide) use ($api) {
     if ($plugin === OPENID_PLUGIN) {
-      echo "\nENTRA-MUPLUGIN - OPENID_PLUGIN has been activated\n";
+      
       WordPress::this_site()->use_new_entra_app($api);
     }
   }, 10, 2);
 
-  add_action('deactivated_plugin', function ($plugin, $network_wide) use ($api) {
-    if ($plugin === OPENID_PLUGIN) {
-      $api->delete_entra_app(WordPress::this_site());
-    }
-  }, 10, 2);
+//   add_action('deactivated_plugin', function ($plugin, $network_wide) use ($api) {
+//     if ($plugin === OPENID_PLUGIN) {
+      
+//       $api->delete_entra_app(WordPress::this_site());
+//     }
+//   }, 10, 2);
 
   add_action('wp_operator_post_restore', function ($unused) use ($api) {
     if (! is_plugin_active(OPENID_PLUGIN)) return;

--- a/entra-app-portal.php
+++ b/entra-app-portal.php
@@ -312,7 +312,7 @@ class AppPortalAPI {
 
 $api = new AppPortalAPI();
 
-define('OPENID_PLUGIN', 'openid-connect-generic/openid-connect-generic.php');
+define('OPENID_PLUGIN', 'daggerhart-openid-connect-generic/openid-connect-generic.php');
 
 if ($api->is_available()) {
   echo "\nApp portal is available\n";

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -129,6 +129,8 @@ class WordPress {
   }
 }
 
+class AppPortalException extends \Exception {}
+
 class AppPortalAPI {
   private function get_api_credentials () {
     $clientId     = getenv('ENTRA_APP_CLIENT_ID');
@@ -256,7 +258,8 @@ class AppPortalAPI {
     curl_close($ch);
 
     if ($httpStatus < 200 || $httpStatus >= 300) {
-      throw new \RuntimeException("{$method} call to {$url} failed: {$httpStatus} {$response}");
+      throw new AppPortalException("{$method} call to {$url} failed: {$response}",
+                                   $httpStatus);
     }
 
     return json_decode($response, true);
@@ -303,14 +306,19 @@ class AppPortalAPI {
   }
 
   public function delete_entra_app ($wordpress) {
-    $response = $this->call_app_portal_api(
-      "DELETE", $this->get_relative_url_of_app($wordpress));
+    $url = $this->get_relative_url_of_app($wordpress);
+    try {
+      $response = $this->call_app_portal_api(
+        "DELETE", $url);
 
-    if ($response["Message"] != "") {
-      throw new \RuntimeException("delete_entra_app failed: " . json_encode($response));
+      if ($response["Message"] != "") {
+        throw new \RuntimeException("delete_entra_app failed: " . json_encode($response));
+      }
+    } catch (AppPortalException $e) {
+      if ($e->getCode() == 404) {
+        error_log("WARNING: deleting {$url}: unknown in app-portal, continuing");
+      }
     }
-
-    return $response;
   }
 }
 

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -100,6 +100,7 @@ class WordPress {
       $oidc_settings["client_secret"] = "";  # So-called single-page Web app
       $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/authorize";
       $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/token";
+      $oidc_settings["issuer"] = "https://login.microsoftonline.com/{$tenantId}/v2.0";
       $oidc_settings["scope"] = "openid profile email {$appId}/.default";
       $oidc_settings["endpoint_userinfo"] = "https://api.epfl.ch/v2/oidc/userinfo?groups&rights=WordPress.Editor";
       $oidc_settings["endpoint_end_session"] = "";

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -100,6 +100,7 @@ class WordPress {
       $oidc_settings["client_secret"] = "";  # So-called single-page Web app
       $oidc_settings["endpoint_login"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/authorize";
       $oidc_settings["endpoint_token"] = "https://login.microsoftonline.com/{$tenantId}/oauth2/v2.0/token";
+      $oidc_settings["endpoint_jwks"] = "https://login.microsoftonline.com/{$tenantId}/discovery/v2.0/keys";
       $oidc_settings["issuer"] = "https://login.microsoftonline.com/{$tenantId}/v2.0";
       $oidc_settings["scope"] = "openid profile email {$appId}/.default";
       $oidc_settings["endpoint_userinfo"] = "https://api.epfl.ch/v2/oidc/userinfo?groups&rights=WordPress.Editor";

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -366,9 +366,16 @@ add_filter('openid-connect-generic-alter-request', function( $request, $operatio
     }
     unset($request['body']['client_secret']);
 
-    $urlparts = wp_parse_url(home_url());
-    $domain = $urlparts['host'];
-    $request['headers']['Origin'] = home_url();
+    if (isset($request['body']['redirect_uri']) &&
+        isset($_SERVER['HTTP_X_KONG_ORIG_HOST'])) {
+      $request['body']['redirect_uri'] = preg_replace(
+        '#^(https?://)[^/]+#',
+        '$1' . $_SERVER['HTTP_X_KONG_ORIG_HOST'],
+        $request['body']['redirect_uri']);
+    }
+
+    # Entra wants to believe that the browser is performing the query:
+    $request['headers']['Origin'] = $request['body']['redirect_uri'];
 
     $state = sanitize_text_field(wp_unslash($_GET['state']));
     $transient_key = 'epfl_oidc_pkce_' . $state;

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -115,6 +115,7 @@ class WordPress {
       $oidc_settings["identify_with_username"] = "";
       $oidc_settings["state_time_limit"] = "";
       $oidc_settings["enforce_privacy"] = 0;
+      $oidc_settings["allow_internal_idp"] = 1;
       $oidc_settings["alternate_redirect_uri"] = "";
       $oidc_settings["token_refresh_enable"] = "";
       $oidc_settings["link_existing_users"] = "1";

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -367,53 +367,6 @@ add_filter('openid-connect-generic-alter-request', function( $request, $operatio
     return $request;
 }, 10, 2);
 
-add_filter('openid-connect-generic-alter-request', function( $request, $operation ) {
-    if ( $operation != 'get-authentication-token' && $operation != 'refresh-token' ) {
-        return $request;
-    }
-    $settings = get_option('openid_connect_generic_settings', array());
-    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
-        return $request;
-    }
-    unset($request['body']['client_secret']);
-
-    $urlparts = wp_parse_url(home_url());
-    $domain = $urlparts['host'];
-    $request['headers']['Origin'] = home_url();
-
-    $state = sanitize_text_field(wp_unslash($_GET['state']));
-    $transient_key = 'epfl_oidc_pkce_' . $state;
-    $code_verifier = get_transient( $transient_key );
-    $request['body']['code_verifier'] = $code_verifier;
-    delete_transient( $transient_key );
-    return $request;
-}, 10, 2);
-
-
-
-add_filter('openid-connect-generic-alter-request', function( $request, $operation ) {
-    if ( $operation != 'get-authentication-token' && $operation != 'refresh-token' ) {
-        return $request;
-    }
-    $settings = get_option('openid_connect_generic_settings', array());
-    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
-        return $request;
-    }
-    unset($request['body']['client_secret']);
-
-    $urlparts = wp_parse_url(home_url());
-    $domain = $urlparts['host'];
-    $request['headers']['Origin'] = home_url();
-
-    $state = sanitize_text_field(wp_unslash($_GET['state']));
-    $transient_key = 'epfl_oidc_pkce_' . $state;
-    $code_verifier = get_transient( $transient_key );
-    $request['body']['code_verifier'] = $code_verifier;
-    delete_transient( $transient_key );
-    return $request;
-}, 10, 2);
-
-
 /**
  * Add check for Accred plugin before validation OpenID login
  * Update user data based on token

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -306,7 +306,7 @@ class AppPortalAPI {
     $response = $this->call_app_portal_api(
       "DELETE", $this->get_relative_url_of_app($wordpress));
 
-    if (! $response["ok"]) {
+    if ($response["Message"] != "") {
       throw new \RuntimeException("delete_entra_app failed: " . json_encode($response));
     }
 

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -277,7 +277,7 @@ class AppPortalAPI {
       "authorizedUsers" => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
       "config_desc" => "WordPress site {$wordpress->url}",
       "description" => "Application for site" . str_replace("/","-",$wordpress->url),
-      "displayName" => "EPFL - WP ({$name})",
+      "displayName" => "WP ({$name})",
       "environmentID" => $this->get_environment_id(),
       "notes" => "Entra application for WordPress site ({$wordpress->url})",
       "spa" => [ "redirectUris" => $wordpress->get_oidc_redirect_urls() ],

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -314,6 +314,144 @@ class AppPortalAPI {
   }
 }
 
+/**
+ * Switch to PKCE workflow if no secret has been provided : used for
+ * single page apps (SAP) configuration
+ */
+
+add_filter('openid-connect-generic-auth-url', function( $url ) {
+    $settings = get_option('openid_connect_generic_settings', array());
+    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
+        return $url;
+    }
+
+    // Generate a random string for the code challenge
+    $code_verifier = bin2hex(random_bytes(64));
+    $hash = hash('sha256', $code_verifier, true);
+    $code_challenge = rtrim(strtr(base64_encode($hash), '+/', '-_'), '=');
+    $url.= '&code_challenge=' . $code_challenge;
+    $url .= '&code_challenge_method=S256';
+
+    $parsed = wp_parse_url($url);
+    $query  = [];
+    parse_str($parsed['query'], $query);
+    $state = $query['state'];
+
+    set_transient(
+        'epfl_oidc_pkce_' . $state,
+        $code_verifier,
+        15 * MINUTE_IN_SECONDS
+    );
+    return $url;
+});
+
+add_filter('openid-connect-generic-alter-request', function( $request, $operation ) {
+    if ( $operation != 'get-authentication-token' && $operation != 'refresh-token' ) {
+        return $request;
+    }
+    $settings = get_option('openid_connect_generic_settings', array());
+    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
+        return $request;
+    }
+    unset($request['body']['client_secret']);
+
+    $urlparts = wp_parse_url(home_url());
+    $domain = $urlparts['host'];
+    $request['headers']['Origin'] = home_url();
+
+    $state = sanitize_text_field(wp_unslash($_GET['state']));
+    $transient_key = 'epfl_oidc_pkce_' . $state;
+    $code_verifier = get_transient( $transient_key );
+    $request['body']['code_verifier'] = $code_verifier;
+    delete_transient( $transient_key );
+    return $request;
+}, 10, 2);
+
+add_filter('openid-connect-generic-alter-request', function( $request, $operation ) {
+    if ( $operation != 'get-authentication-token' && $operation != 'refresh-token' ) {
+        return $request;
+    }
+    $settings = get_option('openid_connect_generic_settings', array());
+    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
+        return $request;
+    }
+    unset($request['body']['client_secret']);
+
+    $urlparts = wp_parse_url(home_url());
+    $domain = $urlparts['host'];
+    $request['headers']['Origin'] = home_url();
+
+    $state = sanitize_text_field(wp_unslash($_GET['state']));
+    $transient_key = 'epfl_oidc_pkce_' . $state;
+    $code_verifier = get_transient( $transient_key );
+    $request['body']['code_verifier'] = $code_verifier;
+    delete_transient( $transient_key );
+    return $request;
+}, 10, 2);
+
+
+
+add_filter('openid-connect-generic-alter-request', function( $request, $operation ) {
+    if ( $operation != 'get-authentication-token' && $operation != 'refresh-token' ) {
+        return $request;
+    }
+    $settings = get_option('openid_connect_generic_settings', array());
+    if (isset($settings['client_secret']) && $settings['client_secret'] !== '') {
+        return $request;
+    }
+    unset($request['body']['client_secret']);
+
+    $urlparts = wp_parse_url(home_url());
+    $domain = $urlparts['host'];
+    $request['headers']['Origin'] = home_url();
+
+    $state = sanitize_text_field(wp_unslash($_GET['state']));
+    $transient_key = 'epfl_oidc_pkce_' . $state;
+    $code_verifier = get_transient( $transient_key );
+    $request['body']['code_verifier'] = $code_verifier;
+    delete_transient( $transient_key );
+    return $request;
+}, 10, 2);
+
+
+/**
+ * Add check for Accred plugin before validation OpenID login
+ * Update user data based on token
+ */
+add_filter('openid-connect-generic-user-login-test', function( $result, $user_claim ) {
+    $state = sanitize_text_field(wp_unslash($_GET['state']));
+    $access_token = get_transient( 'epfl_oidc_access_token_' . $state );
+    do_action("openid_save_user", $access_token, $user_claim);
+    delete_transient( 'epfl_oidc_access_token_' . $state );
+    return $result;
+}, 10, 2);
+
+/**
+ * Update OpenID login button text
+ */
+add_filter('openid-connect-generic-login-button-text', function( $text ) {
+    $text = __('Login EPFL');
+    return $text;
+});
+
+/**
+ * Update plugin configuration fields:
+ *
+ * - hide OpenID client secret
+ * - add field hide login form
+ *
+ */
+add_filter('openid-connect-generic-settings-fields', function( $fields ) {
+    unset($fields["client_secret"]);
+    $fields['hide_login_form'] = array(
+        'title' => __('Hide login form'),
+        'description' => __('Prevent user to log in with Wordpress user/password'),
+        'type' => 'checkbox',
+        'section' => 'authorization_settings',
+    );
+    return $fields;
+});
+
 $api = new AppPortalAPI();
 
 define('OPENID_PLUGIN', 'daggerhart-openid-connect-generic/openid-connect-generic.php');

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -113,7 +113,7 @@ class WordPress {
       $oidc_settings["displayname_format"] = "";
       $oidc_settings["identify_with_username"] = "";
       $oidc_settings["state_time_limit"] = "";
-      $oidc_settings["enforce_privacy"] = "0";
+      $oidc_settings["enforce_privacy"] = 0;
       $oidc_settings["alternate_redirect_uri"] = "";
       $oidc_settings["token_refresh_enable"] = "";
       $oidc_settings["link_existing_users"] = "1";

--- a/epfl-entra.php
+++ b/epfl-entra.php
@@ -274,7 +274,7 @@ class AppPortalAPI {
         $name = substr($name, 0, -1);
     }
     $response = $this->call_app_portal_api("POST", "/app-portal-api/v1/portal/oidc-apps", [
-      "authorizedUsers" => ["AAD_All Outside EPFL Users", "AAD_All Hosts Users", "AAD_All Student Users", "AAD_All Staff Users"],
+      "authorizedUsers" => [],
       "config_desc" => "WordPress site {$wordpress->url}",
       "description" => "Application for site" . str_replace("/","-",$wordpress->url),
       "displayName" => "WP ({$name})",


### PR DESCRIPTION
Beyond reimplementing [WP-Veritas](https://github.com/epfl-si/wp-veritas)'s Entra / app-portal functionality as a mu-plugin in PHP, this PR tackles https://go.epfl.ch/FSD-169: “WordPress : testabilité + Entra” by provisioning  multiple OIDC return URLs (the “main” one, plus one per fruit in the Kong fruit salad) for test sites.

In order to meet https://go.epfl.ch/FSD-169 in a secure fashion, additional PRs should go with this one (please come back here and edit the description when said PRs exist):

- TODO: a PR in https://github.com/epfl-si/wp-operator to consume environment from `Secret/wp-operator-additional-environment`
- TODO: a PR in https://github.com/epfl-si/wp-ops to add `ENTRA_APP_CLIENT_ID`, `ENTRA_APP_CLIENT_SECRET` and `ENTRA_APP_TENANT_ID` to said `Secret/wp-operator-additional-environment`, and also to the environment of `Deployment/wp-cron`
- TODO: A PR to https://github.com/epfl-si/wp-veritas to remove these variables, and the whole [`src/lib/entra.ts`](https://github.com/epfl-si/wp-veritas/blob/master/src/lib/entra.ts)